### PR TITLE
ci: build Docker images once, deploy to all environments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,8 +20,14 @@ on:
           - prod
           - test
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+  BACKEND_IMAGE: ghcr.io/${{ github.repository }}/backend
+  FRONTEND_IMAGE: ghcr.io/${{ github.repository }}/frontend
 
 jobs:
   set-environments:
@@ -76,10 +82,87 @@ jobs:
       - name: Run frontend type check
         run: pnpm --filter annix-frontend type-check
 
+  build-backend:
+    name: Build Backend Image
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.BACKEND_IMAGE }}
+          tags: |
+            type=sha,format=long,prefix=
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.backend
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=backend
+          cache-to: type=gha,mode=max,scope=backend
+
+  build-frontend:
+    name: Build Frontend Image
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.FRONTEND_IMAGE }}
+          tags: |
+            type=sha,format=long,prefix=
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.frontend
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,mode=max,scope=frontend
+
   deploy-backend:
     name: Deploy Backend (${{ matrix.environment }})
     runs-on: ubuntu-latest
-    needs: [test, set-environments]
+    if: github.event_name != 'pull_request'
+    needs: [build-backend, set-environments]
     strategy:
       fail-fast: false
       max-parallel: 3
@@ -94,13 +177,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull backend image
+        run: docker pull ${{ env.BACKEND_IMAGE }}:${{ github.sha }}
+
       - name: Setup Fly.io CLI
         uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy Backend to Fly.io (${{ matrix.environment }})
         run: |
           for i in 1 2 3; do
-            if flyctl deploy -c ${{ matrix.config }}; then
+            if flyctl deploy -c ${{ matrix.config }} \
+              --image ${{ env.BACKEND_IMAGE }}:${{ github.sha }} \
+              --local-only; then
               exit 0
             fi
             echo "Deploy attempt $i failed, retrying in 10s..."
@@ -112,7 +207,8 @@ jobs:
   deploy-frontend:
     name: Deploy Frontend (${{ matrix.environment }})
     runs-on: ubuntu-latest
-    needs: [test, set-environments, deploy-backend]
+    if: github.event_name != 'pull_request'
+    needs: [build-frontend, deploy-backend, set-environments]
     strategy:
       fail-fast: false
       max-parallel: 3
@@ -127,6 +223,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull frontend image
+        run: docker pull ${{ env.FRONTEND_IMAGE }}:${{ github.sha }}
+
       - name: Setup Fly.io CLI
         uses: superfly/flyctl-actions/setup-flyctl@master
 
@@ -134,7 +240,8 @@ jobs:
         run: |
           for i in 1 2 3; do
             if flyctl deploy -c ${{ matrix.config }} \
-              --build-arg NEXT_PUBLIC_GOOGLE_MAPS_API_KEY="${NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}"; then
+              --image ${{ env.FRONTEND_IMAGE }}:${{ github.sha }} \
+              --local-only; then
               exit 0
             fi
             echo "Deploy attempt $i failed, retrying in 10s..."
@@ -142,8 +249,6 @@ jobs:
           done
           echo "All deploy attempts failed"
           exit 1
-        env:
-          NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: ${{ secrets.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY }}
 
       - name: Get Frontend Logs on Failure
         if: failure()

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,44 +1,48 @@
 # syntax=docker/dockerfile:1
-FROM node:24-alpine AS base
-WORKDIR /app
-ARG NEXT_PUBLIC_API_URL=https://annix-backend.fly.dev
-ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
-ARG NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
-ENV NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=${NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}
 
-# ---------- builder ----------
-FROM base AS builder
-RUN apk add --no-cache \
-  python3 make g++ linux-headers pkgconf \
-  libusb-dev eudev-dev libc6-compat
+# ---------- deps ----------
+FROM node:24-alpine AS deps
+WORKDIR /app
+RUN apk add --no-cache python3 make g++ linux-headers pkgconf libusb-dev eudev-dev libc6-compat
 ENV npm_config_python=/usr/bin/python3
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages/product-data/package.json ./packages/product-data/
 COPY annix-frontend/package.json ./annix-frontend/
 RUN corepack enable pnpm && pnpm install --filter annix-frontend --frozen-lockfile
 
+# ---------- builder ----------
+FROM deps AS builder
+ARG NEXT_PUBLIC_API_URL=__NEXT_PUBLIC_API_URL__
+ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
+ARG NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=__NEXT_PUBLIC_GOOGLE_MAPS_API_KEY__
+ENV NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=${NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}
 COPY packages/product-data/ ./packages/product-data/
 COPY annix-frontend/ ./annix-frontend/
-
 WORKDIR /app/annix-frontend
 RUN pnpm run build
 
 # ---------- runner ----------
-FROM base AS runner
+FROM node:24-alpine AS runner
 RUN apk add --no-cache libusb eudev-libs libc6-compat
-
 ENV NODE_ENV=production
-
 RUN addgroup --system --gid 1001 nodejs \
  && adduser --system --uid 1001 nextjs
-USER nextjs
-
 WORKDIR /app
 COPY --from=builder /app/annix-frontend/public ./annix-frontend/public
 COPY --from=builder --chown=nextjs:nodejs /app/annix-frontend/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/annix-frontend/.next/static ./annix-frontend/.next/static
 
+COPY <<'EOF' /app/entrypoint.sh
+#!/bin/sh
+find /app/annix-frontend/.next -name "*.js" -exec sed -i \
+  "s|__NEXT_PUBLIC_API_URL__|${NEXT_PUBLIC_API_URL}|g;s|__NEXT_PUBLIC_GOOGLE_MAPS_API_KEY__|${NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}|g" \
+  {} +
+exec node annix-frontend/server.js
+EOF
+RUN chmod +x /app/entrypoint.sh
+
+USER nextjs
 ENV PORT=3000
 ENV HOSTNAME=0.0.0.0
 EXPOSE 3000
-CMD ["node", "annix-frontend/server.js"]
+CMD ["/app/entrypoint.sh"]

--- a/fly.frontend.test.toml
+++ b/fly.frontend.test.toml
@@ -3,8 +3,6 @@ primary_region = 'jnb'
 
 [build]
   dockerfile = 'Dockerfile.frontend'
-  [build.args]
-    NEXT_PUBLIC_API_URL = 'https://annix-backend-test.fly.dev'
 
 [env]
   NODE_ENV = 'production'

--- a/fly.frontend.toml
+++ b/fly.frontend.toml
@@ -3,8 +3,6 @@ primary_region = 'jnb'
 
 [build]
   dockerfile = 'Dockerfile.frontend'
-  [build.args]
-    NEXT_PUBLIC_API_URL = 'https://annix-backend.fly.dev'
 
 [env]
   NODE_ENV = 'production'


### PR DESCRIPTION
## Summary
- Build each Docker image once (1 backend + 1 frontend) instead of per-environment (was 4 total)
- Push images to ghcr.io tagged by commit SHA, then deploy the same artifact to all environments
- Frontend uses runtime env injection via entrypoint script (sed replaces build-time placeholders with actual env vars at container start)

## Changes
- **Dockerfile.frontend**: Restructured into deps/builder/runner stages with entrypoint script for runtime `NEXT_PUBLIC_*` injection
- **deploy.yml**: Added `build-backend` and `build-frontend` jobs that push to ghcr.io; deploy jobs now pull pre-built images
- **fly.frontend.toml / fly.frontend.test.toml**: Removed `[build.args]` sections (no longer needed)

## Pre-requisite before merging
Set Fly secrets for Google Maps API key on both frontend apps:
```bash
fly secrets set NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=<value> -a annix-frontend
fly secrets set NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=<value> -a annix-frontend-test
```

## Test plan
- [ ] CI passes (test, build-backend, build-frontend jobs)
- [ ] After merge: verify both backend and frontend deploy to prod and test
- [ ] Verify Google Maps functionality works (confirms runtime env injection)
- [ ] Compare pipeline time before/after