### PR TITLE
fix(au-rubber): reclassify COC #171 to Calenderer and add COC type editing

### DIFF
--- a/annix-backend/src/migrations/1809000000017-ReclassifyCoc171ToCalenderer.ts
+++ b/annix-backend/src/migrations/1809000000017-ReclassifyCoc171ToCalenderer.ts
@@ -1,0 +1,21 @@
+import type { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ReclassifyCoc171ToCalenderer1809000000017 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE rubber_supplier_cocs
+      SET coc_type = 'CALENDARER'
+      WHERE id = 171
+        AND coc_type != 'CALENDARER'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE rubber_supplier_cocs
+      SET coc_type = 'COMPOUNDER'
+      WHERE id = 171
+        AND coc_type = 'CALENDARER'
+    `);
+  }
+}

--- a/annix-backend/src/rubber-lining/dto/rubber-coc.dto.ts
+++ b/annix-backend/src/rubber-lining/dto/rubber-coc.dto.ts
@@ -110,6 +110,10 @@ export class UpdateSupplierCocDto {
   @IsOptional()
   @IsEnum(CocProcessingStatus)
   processingStatus?: CocProcessingStatus;
+
+  @IsOptional()
+  @IsEnum(SupplierCocType)
+  cocType?: SupplierCocType;
 }
 
 export class ReviewExtractionDto {

--- a/annix-backend/src/rubber-lining/rubber-coc.service.ts
+++ b/annix-backend/src/rubber-lining/rubber-coc.service.ts
@@ -179,6 +179,7 @@ export class RubberCocService {
     if (dto.orderNumber !== undefined) coc.orderNumber = dto.orderNumber;
     if (dto.ticketNumber !== undefined) coc.ticketNumber = dto.ticketNumber;
     if (dto.processingStatus !== undefined) coc.processingStatus = dto.processingStatus;
+    if (dto.cocType !== undefined) coc.cocType = dto.cocType;
 
     await this.supplierCocRepository.save(coc);
     return this.mapSupplierCocToDto(coc);

--- a/annix-frontend/src/app/au-rubber/portal/supplier-cocs/[id]/page.tsx
+++ b/annix-frontend/src/app/au-rubber/portal/supplier-cocs/[id]/page.tsx
@@ -64,6 +64,7 @@ export default function SupplierCocDetailPage() {
     productionDate: "",
     orderNumber: "",
     ticketNumber: "",
+    cocType: "" as SupplierCocType | "",
   });
   const [editingBatchId, setEditingBatchId] = useState<number | null>(null);
   const [editBatchFields, setEditBatchFields] = useState<Record<string, string>>({});
@@ -179,6 +180,7 @@ export default function SupplierCocDetailPage() {
       productionDate: coc.productionDate ? coc.productionDate.split("T")[0] : "",
       orderNumber: coc.orderNumber || "",
       ticketNumber: coc.ticketNumber || "",
+      cocType: coc.cocType,
     });
     setIsEditing(true);
   };
@@ -193,6 +195,7 @@ export default function SupplierCocDetailPage() {
         productionDate: editFields.productionDate || null,
         orderNumber: editFields.orderNumber || null,
         ticketNumber: editFields.ticketNumber || null,
+        cocType: editFields.cocType || undefined,
       });
       showToast("CoC details updated", "success");
       setIsEditing(false);
@@ -457,6 +460,20 @@ export default function SupplierCocDetailPage() {
                   onChange={(e) => setEditFields({ ...editFields, cocNumber: e.target.value })}
                   className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-yellow-500 focus:ring-yellow-500 text-sm"
                 />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-500">CoC Type</label>
+                <select
+                  value={editFields.cocType}
+                  onChange={(e) =>
+                    setEditFields({ ...editFields, cocType: e.target.value as SupplierCocType })
+                  }
+                  className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-yellow-500 focus:ring-yellow-500 text-sm"
+                >
+                  <option value="COMPOUNDER">Compounder</option>
+                  <option value="CALENDARER">Calenderer (Sheeting)</option>
+                  <option value="CALENDER_ROLL">Calender Roll</option>
+                </select>
               </div>
               <div>
                 <label className="block text-sm font-medium text-gray-500">Compound Code</label>

--- a/annix-frontend/src/app/lib/api/auRubberApi.ts
+++ b/annix-frontend/src/app/lib/api/auRubberApi.ts
@@ -2097,6 +2097,7 @@ class AuRubberApiClient {
       productionDate?: string | null;
       orderNumber?: string | null;
       ticketNumber?: string | null;
+      cocType?: SupplierCocType;
     },
   ): Promise<RubberSupplierCocDto> {
     return this.request(`/rubber-lining/portal/supplier-cocs/${id}`, {


### PR DESCRIPTION
## Summary

- Migration `1809000000017` moves COC #171 from `COMPOUNDER` to `CALENDERER` (sheeting area) as reported in #154
- `cocType` added to `UpdateSupplierCocDto` and `updateSupplierCoc` service method so the type can be persisted via API
- COC type dropdown added to the detail page edit form — admins can now correct misclassifications directly in the UI without needing a new migration each time

## Test plan

- [ ] Verify COC #171 appears under the Calenderer (Sheeting) tab after migration runs
- [ ] Open COC detail page, click Edit, confirm CoC Type dropdown is present with correct current value
- [ ] Change type and save — confirm the tab the COC appears under changes accordingly
- [ ] All 153 backend test suites pass, frontend type-check passes

Ref #154