### PR TITLE
fix(admin): consolidate sidebar dashboard nav item to single label

### DIFF
--- a/annix-frontend/src/app/admin/portal/layout.tsx
+++ b/annix-frontend/src/app/admin/portal/layout.tsx
@@ -14,8 +14,7 @@ import { NixAssistant } from "@/app/lib/nix";
 const navItems = [
   {
     href: "/admin/portal/dashboard",
-    label: "Admin Portal",
-    sublabel: "Dashboard",
+    label: "Dashboard",
     icon: "M7.5 14.25V16.5M10.5 12V16.5M13.5 9.75V16.5M16.5 7.5V16.5M6 20.25H18C19.2426 20.25 20.25 19.2426 20.25 18V6C20.25 4.75736 19.2426 3.75 18 3.75H6C4.75736 3.75 3.75 4.75736 3.75 6V18C3.75 19.2426 4.75736 20.25 6 20.25Z",
     roles: ["admin", "employee"],
   },

--- a/annix-frontend/src/app/annix-rep/settings/integrations/page.tsx
+++ b/annix-frontend/src/app/annix-rep/settings/integrations/page.tsx
@@ -618,32 +618,33 @@ export default function IntegrationsSettingsPage() {
               Active Sessions
             </h3>
             <div className="space-y-2">
-              {activeBotSessions.map((session) => (
-                <Link
-                  key={session.id}
-                  href={`/annix-rep/meetings/${session.meetingId}/transcript`}
-                  className="block bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-gray-200 dark:border-slate-700 p-4 hover:border-purple-300 dark:hover:border-purple-700 transition-colors"
-                >
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-3">
-                      <div className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
-                      <div>
-                        <p className="text-sm font-medium text-gray-900 dark:text-white">
-                          Meeting #{session.meetingId}
-                        </p>
-                        <p className="text-xs text-gray-500 dark:text-gray-400">
-                          {session.participantCount} participants
-                        </p>
+              {activeBotSessions.map((session) => {
+                const statusInfo = botStatusLabels[session.status];
+                return (
+                  <Link
+                    key={session.id}
+                    href={`/annix-rep/meetings/${session.meetingId}/transcript`}
+                    className="block bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-gray-200 dark:border-slate-700 p-4 hover:border-purple-300 dark:hover:border-purple-700 transition-colors"
+                  >
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-3">
+                        <div className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
+                        <div>
+                          <p className="text-sm font-medium text-gray-900 dark:text-white">
+                            Meeting #{session.meetingId}
+                          </p>
+                          <p className="text-xs text-gray-500 dark:text-gray-400">
+                            {session.participantCount} participants
+                          </p>
+                        </div>
                       </div>
+                      <span className={`px-2 py-0.5 text-xs rounded-full ${statusInfo.color}`}>
+                        {statusInfo.label}
+                      </span>
                     </div>
-                    <span
-                      className={`px-2 py-0.5 text-xs rounded-full ${botStatusLabels[session.status].color}`}
-                    >
-                      {botStatusLabels[session.status].label}
-                    </span>
-                  </div>
-                </Link>
-              ))}
+                  </Link>
+                );
+              })}
             </div>
           </div>
         )}
@@ -656,6 +657,7 @@ export default function IntegrationsSettingsPage() {
             <div className="bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-gray-200 dark:border-slate-700 divide-y divide-gray-100 dark:divide-slate-700">
               {botSessionHistory.map((session) => {
                 const sessionMeetingId = session.meetingId;
+                const statusInfo = botStatusLabels[session.status];
                 return (
                   <div key={session.id} className="p-3 flex items-center justify-between">
                     <div className="flex items-center gap-3">
@@ -670,10 +672,8 @@ export default function IntegrationsSettingsPage() {
                         </p>
                       </div>
                     </div>
-                    <span
-                      className={`px-2 py-0.5 text-xs rounded-full ${botStatusLabels[session.status].color}`}
-                    >
-                      {botStatusLabels[session.status].label}
+                    <span className={`px-2 py-0.5 text-xs rounded-full ${statusInfo.color}`}>
+                      {statusInfo.label}
                     </span>
                   </div>
                 );


### PR DESCRIPTION
## Summary

- Removes the stacked two-line "Admin Portal" / "Dashboard" layout from the admin portal sidebar nav item
- The `label: "Admin Portal"` + `sublabel: "Dashboard"` caused `PortalToolbar` to render two stacked lines, which looked squashed and cramped
- Changed to `label: "Dashboard"` with no `sublabel` — the portal context already implies "Admin Portal"
- Also includes two pre-existing build blockers that prevented any pushes:
  - `fix(product-data)`: Turbopack subpath export resolution — `default` conditions pointed to non-existent `dist/` files; updated to point to TypeScript sources (package uses `transpilePackages`)
  - `fix(annix-rep)`: SWC-unsafe `obj[key].prop` bracket access in integrations page JSX caused a silent SWC crash leaving the compiled page.js missing

## Test plan

- [ ] Visit `/admin/portal/dashboard` — sidebar should show "Dashboard" as a single clean label with no stacked second line
- [ ] Sidebar "Global Apps" item should be unchanged
- [ ] Frontend build passes (Turbopack errors resolved)

Ref #157