### PR TITLE
fix(admin): correct conversation and broadcast link hrefs in global-messages

### DIFF
--- a/annix-frontend/src/app/admin/portal/global-messages/page.tsx
+++ b/annix-frontend/src/app/admin/portal/global-messages/page.tsx
@@ -89,7 +89,7 @@ function ConversationCard({
 
   return (
     <Link
-      href={`/admin/portal/messages/conversations/${conversation.id}`}
+      href={`/admin/portal/messages/${conversation.id}`}
       className="block bg-white dark:bg-slate-800 rounded-lg border border-gray-200 dark:border-slate-700 p-4 hover:border-[#323288] hover:shadow-md transition-all"
     >
       {cardContent}
@@ -100,7 +100,7 @@ function ConversationCard({
 function BroadcastCard({ broadcast }: { broadcast: BroadcastDetailDto }) {
   return (
     <Link
-      href={`/admin/portal/messages/broadcasts/${broadcast.id}`}
+      href="/admin/portal/broadcasts"
       className="block bg-white dark:bg-slate-800 rounded-lg border border-gray-200 dark:border-slate-700 p-4 hover:border-purple-500 hover:shadow-md transition-all"
     >
       <div className="flex items-start justify-between gap-4">

--- a/annix-frontend/src/app/annix-rep/settings/integrations/page.tsx
+++ b/annix-frontend/src/app/annix-rep/settings/integrations/page.tsx
@@ -618,32 +618,33 @@ export default function IntegrationsSettingsPage() {
               Active Sessions
             </h3>
             <div className="space-y-2">
-              {activeBotSessions.map((session) => (
-                <Link
-                  key={session.id}
-                  href={`/annix-rep/meetings/${session.meetingId}/transcript`}
-                  className="block bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-gray-200 dark:border-slate-700 p-4 hover:border-purple-300 dark:hover:border-purple-700 transition-colors"
-                >
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-3">
-                      <div className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
-                      <div>
-                        <p className="text-sm font-medium text-gray-900 dark:text-white">
-                          Meeting #{session.meetingId}
-                        </p>
-                        <p className="text-xs text-gray-500 dark:text-gray-400">
-                          {session.participantCount} participants
-                        </p>
+              {activeBotSessions.map((session) => {
+                const statusInfo = botStatusLabels[session.status];
+                return (
+                  <Link
+                    key={session.id}
+                    href={`/annix-rep/meetings/${session.meetingId}/transcript`}
+                    className="block bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-gray-200 dark:border-slate-700 p-4 hover:border-purple-300 dark:hover:border-purple-700 transition-colors"
+                  >
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-3">
+                        <div className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
+                        <div>
+                          <p className="text-sm font-medium text-gray-900 dark:text-white">
+                            Meeting #{session.meetingId}
+                          </p>
+                          <p className="text-xs text-gray-500 dark:text-gray-400">
+                            {session.participantCount} participants
+                          </p>
+                        </div>
                       </div>
+                      <span className={`px-2 py-0.5 text-xs rounded-full ${statusInfo.color}`}>
+                        {statusInfo.label}
+                      </span>
                     </div>
-                    <span
-                      className={`px-2 py-0.5 text-xs rounded-full ${botStatusLabels[session.status].color}`}
-                    >
-                      {botStatusLabels[session.status].label}
-                    </span>
-                  </div>
-                </Link>
-              ))}
+                  </Link>
+                );
+              })}
             </div>
           </div>
         )}
@@ -656,6 +657,7 @@ export default function IntegrationsSettingsPage() {
             <div className="bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-gray-200 dark:border-slate-700 divide-y divide-gray-100 dark:divide-slate-700">
               {botSessionHistory.map((session) => {
                 const sessionMeetingId = session.meetingId;
+                const statusInfo = botStatusLabels[session.status];
                 return (
                   <div key={session.id} className="p-3 flex items-center justify-between">
                     <div className="flex items-center gap-3">
@@ -670,10 +672,8 @@ export default function IntegrationsSettingsPage() {
                         </p>
                       </div>
                     </div>
-                    <span
-                      className={`px-2 py-0.5 text-xs rounded-full ${botStatusLabels[session.status].color}`}
-                    >
-                      {botStatusLabels[session.status].label}
+                    <span className={`px-2 py-0.5 text-xs rounded-full ${statusInfo.color}`}>
+                      {statusInfo.label}
                     </span>
                   </div>
                 );


### PR DESCRIPTION
## Summary

- `ConversationCard` in `/admin/portal/global-messages` was linking to `/admin/portal/messages/conversations/:id` — a route that does not exist. Fixed to `/admin/portal/messages/:id` (the actual `[id]` dynamic route)
- `BroadcastCard` was linking to `/admin/portal/messages/broadcasts/:id` — also non-existent. Fixed to `/admin/portal/broadcasts` (the broadcast management page), since no broadcast detail page exists
- Also includes the same two pre-existing build blockers (Turbopack subpath exports + SWC-unsafe integrations page) so this PR builds cleanly on its own

## Test plan

- [ ] Visit `/admin/portal/global-messages`
- [ ] Click a conversation card → should navigate to `/admin/portal/messages/:id` and show the conversation thread (no 404)
- [ ] Click a broadcast card → should navigate to `/admin/portal/broadcasts` (no 404)

Ref #157